### PR TITLE
feat: upgrade image to debian 10, node 14.15.1, add emoji font

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,6 @@ services:
     build:
       context: node
   xvfb:
-    image: automatio/xvfb:14.5.0-slim
+    image: automatio/xvfb:14.15.1-buster-slim
     build:
       context: xvfb

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,6 @@ services:
 This is same as node:14.5.0-slim image, except has build-essential and dumb-init packages installed for production usage.
 
 
-## automatio/xvfb:14.5.0-slim
+## automatio/xvfb:14.15.1-buster-slim
 
-This is same as node:14.5.0-slim image, except has build-essential and dumb-init packages, as well as many packages and fonts required for running chromium in xvfb.
+This is same as node:14.15.1-buster-slim image, except has build-essential and dumb-init packages, as well as many packages and fonts required for running chromium in xvfb.

--- a/xvfb/Dockerfile
+++ b/xvfb/Dockerfile
@@ -1,13 +1,13 @@
-FROM node:14.5.0-slim
+FROM node:14.15.1-buster-slim
 
 # Install XVFB dependencies
 RUN apt-get update &&\
-  apt-get install -yq build-essential gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-  libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-  libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
-  libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-  ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget \
-  xvfb x11vnc x11-xkb-utils xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic x11-apps dumb-init &&\
-  rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+  apt-get install -yq build-essential gconf-service fonts-noto-color-emoji libasound2 libatk1.0-0 libc6 libcairo2 \
+  libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm-dev libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
+  libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
+  libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
+  fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget xvfb x11vnc x11-xkb-utils xfonts-100dpi \
+  xfonts-75dpi xfonts-scalable xfonts-cyrillic x11-apps dumb-init && \
+  rm -rf /var/lib/apt/lists/* /var/cache/apt/* 
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]


### PR DESCRIPTION
This
* updates base OS image from Debian 9 to 10
* updates node.js to 14.15.1
* adds emoji font used on debian-based systems