### PR TITLE
feat: prepackaged chromium for puppeteer 8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,7 @@ services:
     image: automatio/xvfb:14.16.1-buster-slim
     build:
       context: xvfb
+  puppeteer:
+    image: automatio/xvfb-puppeteer:8.0.0
+    build:
+      context: puppeteer

--- a/puppeteer/Dockerfile
+++ b/puppeteer/Dockerfile
@@ -1,0 +1,18 @@
+FROM automatio/xvfb:14.16.1-buster-slim
+
+WORKDIR /opt
+
+RUN YARN_CACHE_FOLDER=/tmp/yarn_cache yarn add puppeteer@8.0.0 && \
+    yarn cache clean && \
+    rm -rf /tmp/yarn_cache && \
+    rm -rf /usr/local/share/.cache && \
+    CHROME_PATH=$(find node_modules/puppeteer/.local-chromium/ -type d -name chrome-linux) && \
+    mv $CHROME_PATH /opt/.local-chromium && \
+    rm -rf node_modules && \
+    rm package.json && \
+    rm yarn.lock
+
+RUN ln -s /opt/.local-chromium/chrome /usr/bin/google-chrome
+RUN ln -s /opt/.local-chromium/chrome /usr/bin/chromium-browser
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/readme.md
+++ b/readme.md
@@ -30,3 +30,8 @@ This is same as node:14.16.1-slim image, except has build-essential and dumb-ini
 ## automatio/xvfb:14.16.1-buster-slim
 
 This is same as node:14.16.1-buster-slim image, except has build-essential and dumb-init packages, as well as many packages and fonts required for running chromium in xvfb.
+
+
+## automatio/xvfb-puppeteer:8.0.0
+
+This is same as automatio/xvfb:14.16.1-buster-slim image, but it also has Chromium for the indicated puppeteer version, located at `/usr/bin/chromium-browser`


### PR DESCRIPTION
This creates a new image with pre-downloaded Chromium used for puppeteer 8.0.0.

No puppeteer though.